### PR TITLE
use ThreadPoolExecutor to impl worker for mproc

### DIFF
--- a/pytest_concurrent.py
+++ b/pytest_concurrent.py
@@ -126,14 +126,17 @@ def pytest_runtestloop(session):
 def _run_items(mode, items, session, workers=None):
     ''' Multiprocess is not compatible with Windows !!! '''
     if mode == "mproc":
-        procs_pool = dict()
+        '''Using ThreadPoolExecutor as managers to control the lifecycle of processes.
+        Each thread will spawn a process and terminates when the process joins.
+        '''
+        def run_task_in_proc(item, index):
+            proc = multiprocessing.Process(target=_run_next_item, args=(session, item, index))
+            proc.start()
+            proc.join()
 
-        for index, item in enumerate(items):
-            procs_pool[index] = multiprocessing.Process(target=_run_next_item, args=(session, item, index))
-            procs_pool[index].start()
-
-        for proc in procs_pool:
-            procs_pool[proc].join()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            for index, item in enumerate(items):
+                executor.submit(run_task_in_proc, item, index)
 
     elif mode == "mthread":
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:


### PR DESCRIPTION
Originally it was using `multiprocessing.Process` directly to achieve multi-process mode. However, due to the underlying implementation of pytest session item, it's not really possible to pickle the object so cannot use `ProcessPoolExecutor` directly.

This PR is intended to give `mproc` mode the ability of setting worker amount by using `ThreadPoolExecutor` to manage the lifecycle of proc.