### PR TITLE
Pytest closest marker fix

### DIFF
--- a/pytest_concurrent/plugin.py
+++ b/pytest_concurrent/plugin.py
@@ -64,7 +64,7 @@ def pytest_runtestloop(session):
     groups = collections.defaultdict(list)
     ungrouped_items = list()
     for item in session.items:
-        concurrent_group_marker = item.get_marker('concgroup')
+        concurrent_group_marker = item.get_closest_marker('concgroup')
         concurrent_group = None
 
         if concurrent_group_marker is not None:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-concurrent',
-    version='0.2.0',
+    version='0.2.1',
     author='James Wang, Reverb Chu',
     author_email='jamesw96@uw.edu, reverbc@me.com',
     maintainer='James Wang, Reverb Chu',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py33,py34,py35,py36,flake8
+envlist = py27,py33,py34,py35,py36,py37,flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Issue #29. Change item.get_marker to item.get_closest_marker.
Adding py37 to tox. Upping version to 0.2.1